### PR TITLE
Implement backend Google login route

### DIFF
--- a/app/Http/Controllers/Auth/GoogleAuthController.php
+++ b/app/Http/Controllers/Auth/GoogleAuthController.php
@@ -43,12 +43,14 @@ class GoogleAuthController extends Controller
             // 4. Buscamos o creamos al usuario en nuestra base de datos
             // Usamos updateOrCreate para manejar tanto registros nuevos como existentes.
             $user = User::updateOrCreate(
-                ['google_id' => $googleId], // Busca por el ID de Google para ser más robusto
+                ['google_id' => $googleId],
                 [
-                    'email' => $email, // Actualiza el email por si cambia
+                    'email' => $email,
                     'name' => $name,
                     'avatar' => $avatar,
-                    'password' => bcrypt(str()->random(16)) // Asigna una contraseña aleatoria segura
+                    'type_user' => 'CLIENT',
+                    'email_verified_at' => now(),
+                    'password' => bcrypt(str()->random(16))
                 ]
             );
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ class User extends Authenticatable implements JWTSubject
         'avatar',
         'phone',
         'email',
+        'google_id',
         "uniqd",
         "code_verified",
         'password',

--- a/database/migrations/2025_06_05_220708_add_google_id_to_users_table.php
+++ b/database/migrations/2025_06_05_220708_add_google_id_to_users_table.php
@@ -12,7 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            if (!Schema::hasColumn('users', 'google_id')) {
+                $table->string('google_id')->nullable()->unique()->after('email');
+            }
         });
     }
 
@@ -22,7 +24,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            if (Schema::hasColumn('users', 'google_id')) {
+                $table->dropColumn('google_id');
+            }
         });
     }
 };

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Admin\Product\ProductVariationsController;
 use App\Http\Controllers\Admin\Product\ProductSpecificationsController;
 use App\Http\Controllers\Admin\Product\ProductVariationsAnidadoController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Auth\GoogleAuthController;
 
 /*
 |--------------------------------------------------------------------------
@@ -44,6 +45,8 @@ Route::group([
     Route::post('/login', [AuthController::class, 'login'])->name('login');
     Route::post('/login_ecommerce', [AuthController::class, 'login_ecommerce'])->name('login_ecommerce');
     Route::post('/google_login', [AuthController::class, 'googleLogin'])->name('google_login');
+    // Nueva ruta para login via token de Google
+    Route::post('/google', [\App\Http\Controllers\Auth\GoogleAuthController::class, 'handleGoogleCallback'])->name('google');
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
     Route::post('/refresh', [AuthController::class, 'refresh'])->name('refresh');
     Route::post('/me', [AuthController::class, 'me'])->name('me');


### PR DESCRIPTION
## Summary
- add `google_id` to fillable fields
- implement migration to add `google_id` column
- update GoogleAuthController to create/update user and mark them verified
- expose new `POST /auth/google` route

## Testing
- `npm test --silent` *(fails: no tests configured)*
- `./vendor/bin/phpunit --testdox` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac68f9408322a1919ad14e2a00c3