### PR TITLE
Add assertions for JWT in Google login tests

### DIFF
--- a/tests/Feature/GoogleLoginTest.php
+++ b/tests/Feature/GoogleLoginTest.php
@@ -44,6 +44,7 @@ class GoogleLoginTest extends TestCase
         ]);
 
         $response->assertOk();
+        $this->assertNotEmpty($response->json('access_token'));
 
         $this->assertDatabaseHas('users', [
             'google_id' => 'google123',
@@ -77,6 +78,7 @@ class GoogleLoginTest extends TestCase
         ]);
 
         $response->assertOk();
+        $this->assertNotEmpty($response->json('access_token'));
 
         $this->assertDatabaseCount('users', 1);
 


### PR DESCRIPTION
## Summary
- verify Google login returns an access token when creating or updating the user

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68433d0bb8c4832295aa63d1e2c09ea7