### PR TITLE
Limit client product creation

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,5 +65,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'permission' => \App\Http\Middleware\CheckPermission::class,
+        'product.limit' => \App\Http\Middleware\CheckProductLimit::class,
     ];
 }

--- a/app/Http/Middleware/CheckProductLimit.php
+++ b/app/Http/Middleware/CheckProductLimit.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Models\Product\Product;
+
+class CheckProductLimit
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = auth('api')->user();
+        if (!$user) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        // Admin users have no limit
+        if ($user->hasRole('Admin')) {
+            return $next($request);
+        }
+
+        $count = Product::where('user_id', $user->id)->count();
+        if ($count >= 3) {
+            return response()->json([
+                'message' => 'Solo puedes crear hasta 3 productos'
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Product/Product.php
+++ b/app/Models/Product/Product.php
@@ -54,6 +54,11 @@ class Product extends Model
         return $this->belongsTo(Brand::class,"brand_id");
     }
 
+    public function user()
+    {
+        return $this->belongsTo(\App\Models\User::class, 'user_id');
+    }
+
     public function images() {
         return $this->hasMany(ProductImage::class,"product_id");
     }

--- a/database/factories/Product/ProductFactory.php
+++ b/database/factories/Product/ProductFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories\Product;
+
+use App\Models\Product\Product;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->unique()->word(),
+            'slug' => $this->faker->slug(),
+            'imagen' => 'products/test.jpg',
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2025_01_01_000000_create_products_table.php
+++ b/database/migrations/2025_01_01_000000_create_products_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->nullable();
+            $table->string('imagen')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -80,7 +80,7 @@ Route::group([
     Route::middleware(['permission:manage-products|manage-own-products'])->group(function () {
         Route::get("products/config", [ProductController::class, "config"]);
         Route::post("products/index", [ProductController::class, "index"]);
-        Route::post("products", [ProductController::class, "store"]);
+        Route::post("products", [ProductController::class, "store"])->middleware('product.limit');
         Route::get("products/{id}", [ProductController::class, "show"]);
         Route::post("products/{id}", [ProductController::class, "update"]);
         Route::delete("products/{id}", [ProductController::class, "destroy"]);

--- a/tests/Feature/ProductLimitTest.php
+++ b/tests/Feature/ProductLimitTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Product\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ProductLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+    }
+
+    private function createClient(): User
+    {
+        $user = User::factory()->create(['type_user' => 2]);
+        $role = Role::firstOrCreate(['name' => 'Usuario'], ['description' => 'Cliente']);
+        $user->roles()->sync([$role->id]);
+        return $user;
+    }
+
+    private function createAdmin(): User
+    {
+        $user = User::factory()->create(['type_user' => 1]);
+        $role = Role::firstOrCreate(['name' => 'Admin'], ['description' => 'Admin']);
+        $user->roles()->sync([$role->id]);
+        return $user;
+    }
+
+    private function productPayload(): array
+    {
+        return [
+            'title' => 'Prod ' . uniqid(),
+            'portada' => UploadedFile::fake()->image('prod.jpg'),
+        ];
+    }
+
+    public function test_client_can_create_up_to_three_products(): void
+    {
+        $user = $this->createClient();
+        $this->actingAs($user, 'api');
+
+        for ($i = 1; $i <= 3; $i++) {
+            $response = $this->postJson('/api/admin/products', $this->productPayload());
+            $response->assertStatus(200);
+        }
+    }
+
+    public function test_client_cannot_create_more_than_three_products(): void
+    {
+        $user = $this->createClient();
+        Product::factory()->count(3)->create(['user_id' => $user->id]);
+        $this->actingAs($user, 'api');
+
+        $response = $this->postJson('/api/admin/products', $this->productPayload());
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_has_no_product_limit(): void
+    {
+        $user = $this->createAdmin();
+        $this->actingAs($user, 'api');
+
+        for ($i = 1; $i <= 5; $i++) {
+            $response = $this->postJson('/api/admin/products', $this->productPayload());
+            $response->assertStatus(200);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce max 3 products per non-admin user
- register middleware alias and apply to product route
- add belongsTo user relation to Product model
- create minimal products table and factory for tests
- cover cases with new ProductLimitTest

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b78eb640083228865bb67fa1a2ba5